### PR TITLE
Add GPU attestation check in OTTP server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,3 @@ members = [
   "ohttp-server",
   "cgpuvm-attest",
 ]
-
-[patch.crates-io]
-# The below pacakges requires Rust 1.81 and does not work with Rust 1.75
-litemap = { version = "=0.7.4" } 
-zerofrom = { version = "=0.1.5" } 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ members = [
   "ohttp-server",
   "cgpuvm-attest",
 ]
+
+[patch.crates-io]
+# The below pacakges requires Rust 1.81 and does not work with Rust 1.75
+litemap = { version = "=0.7.4" } 
+zerofrom = { version = "=0.1.5" } 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ run-server-container-cvm:
 	docker run --privileged --net=host \
 	-e TARGET=${TARGET} -e MAA_URL=${MAA} -e KMS_URL=${KMS}/app/key -e INJECT_HEADERS=${INJECT_HEADERS} \
 	--mount type=bind,source=/sys/kernel/security,target=/sys/kernel/security \
-	--device /dev/tpmrm0  attested-ohttp-server \
-	-v /usr/local/lib/local_gpu_verifier/outputs:/var/local_gpu_verifier_outputs:ro
+	--device /dev/tpmrm0  attested-ohttp-server
 
 # Whisper deployments
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ run-server-container-cvm:
 	docker run --privileged --net=host \
 	-e TARGET=${TARGET} -e MAA_URL=${MAA} -e KMS_URL=${KMS}/app/key -e INJECT_HEADERS=${INJECT_HEADERS} \
 	--mount type=bind,source=/sys/kernel/security,target=/sys/kernel/security \
-	--device /dev/tpmrm0  attested-ohttp-server
+	--device /dev/tpmrm0  attested-ohttp-server \
+	-v /usr/local/lib/local_gpu_verifier/outputs:/var/local_gpu_verifier_outputs:ro
 
 # Whisper deployments
 

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -53,4 +53,6 @@ hyper = "0.14"  # Use the latest patch version for the 0.14.x series
 ohttp-client = {path = "../external/attested-ohttp-client/ohttp-client" }
 
 [patch.crates-io]
-litemap = { version = "=0.7.4" }    # litemap 0.7.5 needs Rust 1.81 and does not work with Rust 1.75
+# The below pacakges requires Rust 1.81 and does not work with Rust 1.75
+litemap = { version = "=0.7.4" } 
+zerofrom = { version = "=0.1.5" } 

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -32,9 +32,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-filter"] }
 thiserror = "1"
 uuid = { version = "1.0", features = ["v4"] }
-# The below pacakges requires Rust 1.81 and does not work with Rust 1.75
-litemap = { version = "=0.7.4" } 
-zerofrom = { version = "=0.1.5" } 
 
 [dependencies.cgpuvm-attest]
 path= "../cgpuvm-attest"

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -51,3 +51,6 @@ default-features = false
 [dev-dependencies]
 hyper = "0.14"  # Use the latest patch version for the 0.14.x series
 ohttp-client = {path = "../external/attested-ohttp-client/ohttp-client" }
+
+[patch.crates-io]
+litemap = { version = "=0.7.4" }    # litemap 0.7.5 needs Rust 1.81 and does not work with Rust 1.75

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -51,8 +51,3 @@ default-features = false
 [dev-dependencies]
 hyper = "0.14"  # Use the latest patch version for the 0.14.x series
 ohttp-client = {path = "../external/attested-ohttp-client/ohttp-client" }
-
-[patch.crates-io]
-# The below pacakges requires Rust 1.81 and does not work with Rust 1.75
-litemap = { version = "=0.7.4" } 
-zerofrom = { version = "=0.1.5" } 

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -32,6 +32,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-filter"] }
 thiserror = "1"
 uuid = { version = "1.0", features = ["v4"] }
+# The below pacakges requires Rust 1.81 and does not work with Rust 1.75
+litemap = { version = "=0.7.4" } 
+zerofrom = { version = "=0.1.5" } 
 
 [dependencies.cgpuvm-attest]
 path= "../cgpuvm-attest"

--- a/ohttp-server/src/err.rs
+++ b/ohttp-server/src/err.rs
@@ -27,4 +27,6 @@ pub enum ServerError {
     PrivateKeyMissing,
     #[error("Guest attestation library failed to decrypt HPKE private key")]
     TPMDecryptionFailure,
+    #[error("GPU attestation failed: {0}")]
+    GPUAttestationFailure(String),
 }

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -675,7 +675,7 @@ fn is_gpu_attestation_ok() -> bool {
 // Check whether the GPU attstation log has attestation successful message
 fn do_gpu_attestation_or_fail() -> Result<(), Box<dyn std::error::Error>> {
     // Read GPU attestation output file
-    let contents = fs::read_to_string(GPU_ATTESTATION_RESULT_PATH).map_err(|e| {
+    let contents = read_to_string(GPU_ATTESTATION_RESULT_PATH).map_err(|e| {
         let error_msg = format!("Failed to read GPU attestation output file '{GPU_ATTESTATION_RESULT_PATH}': {e}");
         Box::new(ServerError::GPUAttestationFailure(error_msg)) as Box<dyn std::error::Error>
     })?;

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -5,8 +5,15 @@
 
 pub mod err;
 
-use std::{io::Cursor, net::SocketAddr, sync::Arc, fs::read_to_string};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    fs::read_to_string,
+    io::Cursor,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use lazy_static::lazy_static;
 use moka::future::Cache;
@@ -57,7 +64,8 @@ const KID_NOT_FOUND_RETRY_TIMER: u64 = 60;
 const DEFAULT_KMS_URL: &str = "https://accconfinferenceprod.confidential-ledger.azure.com/app/key";
 const DEFAULT_MAA_URL: &str = "https://confinfermaaeus2test.eus2.test.attest.azure.net";
 const FILTERED_RESPONSE_HEADERS: [&str; 2] = ["content-type", "content-length"];
-const GPU_ATTESTATION_RESULT_PATH: &str = "/var/local_gpu_verifier_outputs/gpu_attestation_results.log";
+const GPU_ATTESTATION_RESULT_PATH: &str =
+    "/var/local_gpu_verifier_outputs/gpu_attestation_results.log";
 
 #[derive(Debug, Parser, Clone)]
 #[command(name = "ohttp-server", about = "Serve oblivious HTTP requests.")]
@@ -676,7 +684,9 @@ fn is_gpu_attestation_ok() -> bool {
 fn do_gpu_attestation_or_fail() -> Result<(), Box<dyn std::error::Error>> {
     // Read GPU attestation output file
     let contents = read_to_string(GPU_ATTESTATION_RESULT_PATH).map_err(|e| {
-        let error_msg = format!("Failed to read GPU attestation output file '{GPU_ATTESTATION_RESULT_PATH}': {e}");
+        let error_msg = format!(
+            "Failed to read GPU attestation output file '{GPU_ATTESTATION_RESULT_PATH}': {e}"
+        );
         Box::new(ServerError::GPUAttestationFailure(error_msg)) as Box<dyn std::error::Error>
     })?;
 

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -57,7 +57,7 @@ const KID_NOT_FOUND_RETRY_TIMER: u64 = 60;
 const DEFAULT_KMS_URL: &str = "https://accconfinferenceprod.confidential-ledger.azure.com/app/key";
 const DEFAULT_MAA_URL: &str = "https://confinfermaaeus2test.eus2.test.attest.azure.net";
 const FILTERED_RESPONSE_HEADERS: [&str; 2] = ["content-type", "content-length"];
-const GPU_ATTESTATION_RESULT_PATH: &str = "/var/gpu_attestation_result.log";
+const GPU_ATTESTATION_RESULT_PATH: &str = "/var/local_gpu_verifier_outputs/gpu_attestation_results.log";
 
 #[derive(Debug, Parser, Clone)]
 #[command(name = "ohttp-server", about = "Serve oblivious HTTP requests.")]

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -694,20 +694,25 @@ fn do_gpu_attestation_or_fail() -> Result<(), Box<dyn std::error::Error>> {
 async fn main() -> Res<()> {
     init();
 
-    // Check GPU attestation at startup
-    match do_gpu_attestation_or_fail() {
-        Ok(()) => {
-            set_gpu_attestation_ok(true);
-            info!("GPU attestation check succeeded");
-        }
-        Err(e) => {
-            set_gpu_attestation_ok(false);
-            error!("GPU attestation check failed: {e}");
-        }
-    }
-
     let args = Args::parse();
     let address = args.address;
+
+    // Check GPU attestation at startup
+    if args.local_key {
+        set_gpu_attestation_ok(true);
+        info!("GPU attestation check skipped for local testing");
+    } else {
+        match do_gpu_attestation_or_fail() {
+            Ok(()) => {
+                set_gpu_attestation_ok(true);
+                info!("GPU attestation check succeeded");
+            }
+            Err(e) => {
+                set_gpu_attestation_ok(false);
+                error!("GPU attestation check failed: {e}");
+            }
+        }
+    }
 
     // Generate a fresh key for local testing. KID is set to 0.
     if args.local_key {

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -6,6 +6,7 @@
 pub mod err;
 
 use std::{io::Cursor, net::SocketAddr, sync::Arc, fs::read_to_string};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use lazy_static::lazy_static;
 use moka::future::Cache;

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -324,7 +324,9 @@ async fn load_config_token(
     if !is_gpu_attestation_ok() {
         let error_msg = "GPU attestation flag is set to false";
         error!("{error_msg}");
-        Err(Box::new(ServerError::GPUAttestationFailure(error_msg.into())))?;
+        Err(Box::new(ServerError::GPUAttestationFailure(
+            error_msg.into(),
+        )))?;
     }
 
     let mut attestation_client = match AttestationClient::new() {

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -661,22 +661,23 @@ async fn do_gpu_attestation_or_fail(x_ms_request_id: Uuid) -> Res<()> {
         .get(DEFAULT_GPU_ATTESTATION_URL)
         .header("x-request-id", x_ms_request_id.to_string())
         .send()
-        .await {
-            Ok(response) => response,
-            Err(e) => {
-                return Err(Box::new(ServerError::GPUAttestationFailure(
-                    format!("Failed to connect to GPU Attestation Service: {e}")
-                )));
-            }
-        };
+        .await
+    {
+        Ok(response) => response,
+        Err(e) => {
+            return Err(Box::new(ServerError::GPUAttestationFailure(format!(
+                "Failed to connect to GPU Attestation Service: {e}"
+            ))));
+        }
+    };
 
     let status = resp.status();
     let body = resp.text().await?;
 
     if !status.is_success() {
-        return Err(Box::new(ServerError::GPUAttestationFailure(
-            format!("status code = {status}, body = {body}")
-        )));
+        return Err(Box::new(ServerError::GPUAttestationFailure(format!(
+            "status code = {status}, body = {body}"
+        ))));
     }
 
     info!("Local GPU attestation succeeded: {body}");

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -685,6 +685,7 @@ fn do_gpu_attestation_or_fail() -> Result<(), Box<dyn std::error::Error>> {
         let error_msg = format!(
             "Failed to read GPU attestation output file '{GPU_ATTESTATION_RESULT_PATH}': {e}"
         );
+        error!("{error_msg}");
         Box::new(ServerError::GPUAttestationFailure(error_msg)) as Box<dyn std::error::Error>
     })?;
 
@@ -692,6 +693,7 @@ fn do_gpu_attestation_or_fail() -> Result<(), Box<dyn std::error::Error>> {
     let gpu_attestation_successful_msg = "Attestation successful";
     if !contents.contains(gpu_attestation_successful_msg) {
         let error_msg = format!("File '{GPU_ATTESTATION_RESULT_PATH}' does not contain '{gpu_attestation_successful_msg}'");
+        error!("{error_msg}");
         return Err(Box::new(ServerError::GPUAttestationFailure(error_msg)));
     }
 

--- a/ohttp-server/src/main.rs
+++ b/ohttp-server/src/main.rs
@@ -470,7 +470,7 @@ async fn score(
         Some(kid) => kid,
     };
 
-    // If attestation check at startup failed, return 500
+    // If GPU attestation check at startup failed, return 500
     if !is_gpu_attestation_ok() {
         error!("Score request denied because GPU attestation failed at startup.");
         let error_msg = "GPU attestation failure";


### PR DESCRIPTION
This pull request introduces GPU attestation checks to the `ohttp-server` project. The changes include adding new error handling, constants, and functions to support GPU attestation, as well as modifying the server startup and request handling to incorporate these checks.

### GPU Attestation Integration:

* **Error Handling:**
  - Added a new error variant `GPUAttestationFailure` to the `ServerError` enum to handle GPU attestation failures.

* **Constants and Atomic Variables:**
  - Introduced a new constant `GPU_ATTESTATION_RESULT_PATH` to specify the path to the GPU attestation results log file.
  - Added a new atomic boolean `GPU_ATTESTATION_OK` to track the status of GPU attestation.

* **Functions for GPU Attestation:**
  - Implemented `set_gpu_attestation_ok`, `is_gpu_attestation_ok`, and `do_gpu_attestation_or_fail` functions to manage and verify GPU attestation status.

* **Server Startup and Request Handling:**
  - Modified the `main` function to check GPU attestation at server startup and set the attestation status accordingly.
  - Updated the `load_config_token` function to check GPU attestation before proceeding with other operations.
  - Included GPU attestation checks during server startup within the test module.

* **Makefile Update:**
  - Updated the `run-server-container-cvm` target in the `Makefile` to mount the GPU attestation outputs directory as a read-only volume.