### PR TITLE
Add azure attestation proxy service.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
   "ohttp-server",
   "cgpuvm-attest",
+  "azure-attestation-proxy",
 ]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ make build-whisper-container
 Next, clone and build the attested OHTTP client container. 
 
 ```
+git submodule init
 git submodule update --recursive
 make build-client-container
 ```

--- a/azure-attestation-proxy/Cargo.toml
+++ b/azure-attestation-proxy/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "azure-attestation-proxy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-filter"] }
+warp = { version = "0.3", features = ["tls"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+bytes = "1.10.1"
+thiserror = "2.0.12"
+hyper = { version = "0.14", features = ["client", "http1"] }
+http = "0.2"
+hyper-unix-connector = "0.2.2"
+
+[dependencies.cgpuvm-attest]
+path= "../cgpuvm-attest"
+features = []

--- a/azure-attestation-proxy/README.md
+++ b/azure-attestation-proxy/README.md
@@ -1,0 +1,11 @@
+## Installation
+sudo ./install.sh --enable-service
+
+## Testing
+curl --unix-socket /var/run/azure-attestation-proxy/azure-attestation-proxy.sock http://localhost/attest -H "maa: https://confinfermaaeus2test.eus2.test.attest.azure.net" -H "x-ms-request-id: 12345678-1234-5678-1234-567812345678"
+
+sudo RUST_LOG=trace cargo test -- tests
+
+## Debugging
+systemctl status azure-attestation-proxy.service
+journalctl -xeu azure-attestation-proxy.service

--- a/azure-attestation-proxy/azure-attestation-proxy.service
+++ b/azure-attestation-proxy/azure-attestation-proxy.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Azure Attestation Proxy Service on socket
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# Ensure the socket directory exists
+ExecStartPre=/bin/mkdir -p /var/run/azure-attestation-proxy
+ExecStartPre=/bin/chmod 755 /var/run/azure-attestation-proxy
+
+# Ensure the binary exists before starting
+ExecStartPre=/bin/bash -c 'if [ ! -x /usr/local/bin/azure-attestation-proxy/azure-attestation-proxy ]; then echo "Binary missing: /usr/local/bin/azure-attestation-proxy/azure-attestation-proxy" >&2; exit 1; fi'
+
+# Execute CVM Attestation Service binary
+ExecStart=/usr/local/bin/azure-attestation-proxy/azure-attestation-proxy
+
+# Restart on failures
+Restart=on-failure
+RestartSec=5s
+
+Environment="RUST_LOG=trace"
+
+# Use journald for stdout/err
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/azure-attestation-proxy/install.sh
+++ b/azure-attestation-proxy/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# A script to build and install the CVM attestation service.
+#
+# Usage:
+#   cd azure-attestation-proxy
+#   sudo bash ./install.sh [--enable-service]
+#
+
+set -e
+
+# Default values for arguments
+ENABLE_SERVICE=0
+
+# Parse command-line arguments
+for arg in "$@"; do
+    case "$arg" in
+        --enable-service)
+            ENABLE_SERVICE=1
+            ;;
+        *)
+            echo "Invalid argument: $arg"
+            echo "Usage: $0 [--enable-service]"
+            exit 1
+            ;;
+    esac
+done
+
+# Go to the directory of this script
+cd "$(dirname "$0")"
+
+CVM_ATTESTATION_PATH="/usr/local/bin/azure-attestation-proxy"
+SERVICE_NAME="azure-attestation-proxy"
+
+cargo build 
+
+# Stop the existing systemd service BEFORE copying the new binary if it's running
+if [ "$ENABLE_SERVICE" = "1" ]; then
+    echo "Stopping existing '$SERVICE_NAME' service (if running)..."
+    sudo systemctl stop "$SERVICE_NAME" || true
+fi
+
+# Install the binary
+echo "Installing azure-attestation-proxy-service to $CVM_ATTESTATION_PATH..."
+sudo mkdir -p "$CVM_ATTESTATION_PATH"
+sudo cp ../target/debug/azure-attestation-proxy "$CVM_ATTESTATION_PATH"
+sudo chmod +x "$CVM_ATTESTATION_PATH/azure-attestation-proxy"
+
+echo "Installation complete!"
+echo "Binary installed at: $CVM_ATTESTATION_PATH/azure-attestation-proxy"
+
+# Enable and start the service
+if [ "$ENABLE_SERVICE" = "1" ]; then
+    echo "Setting up systemd service for '$SERVICE_NAME'..."
+    sudo cp azure-attestation-proxy.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable "$SERVICE_NAME"
+    sudo systemctl start "$SERVICE_NAME"
+    echo "Service '$SERVICE_NAME' is enabled and running."
+fi

--- a/azure-attestation-proxy/src/lib.rs
+++ b/azure-attestation-proxy/src/lib.rs
@@ -1,0 +1,146 @@
+use std::{os::unix::fs::PermissionsExt, path::Path};
+use tokio::net::UnixListener;
+use tracing::{error, info, instrument, trace};
+
+pub const VERSION: &str = "0.0.74.3";
+
+pub type Res<T> = Result<T, Box<dyn std::error::Error>>;
+
+pub const PCR0_TO_15_BITMASK: u32 = 0xFFFF;
+
+use cgpuvm_attest::AttestationClient;
+
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum ServerError {
+    #[error("CVM guest attestation library initialization failure")]
+    AttestationLibraryInit,
+    #[error("Guest attestation library failed to decrypt HPKE private key")]
+    TPMDecryptionFailure,
+}
+
+pub async fn get_socket_listener(socket_path: &str) -> Res<UnixListener> {
+    trace!("Starting unix-socket-service on {}", socket_path);
+
+    // Remove existing socket file if it exists
+    if Path::new(socket_path).exists() {
+        match std::fs::remove_file(socket_path) {
+            Ok(_) => trace!("Removed existing socket file"),
+            Err(e) => {
+                error!("Failed to remove existing socket file: {}", e);
+                return Err(Box::new(e));
+            }
+        }
+        trace!("Removed existing socket file");
+    }
+
+    // Create a new UnixListener bound to the specified socket path
+    let listener = match UnixListener::bind(socket_path) {
+        Ok(listener) => listener,
+        Err(e) => {
+            error!("Failed to bind to socket: {}", e);
+            return Err(Box::new(e));
+        }
+    };
+    info!("Server listening on {}", socket_path);
+
+    // Set permissions for the socket file (e.g., readable/writable by all)
+    match std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o666)) {
+        Ok(_) => trace!("Set socket permissions to 0666"),
+        Err(e) => {
+            error!("Failed to set socket permissions: {}", e);
+            return Err(Box::new(e));
+        }
+    }
+
+    Ok(listener)
+}
+
+fn create_attestation_client() -> Res<AttestationClient> {
+    let attestation_client = match AttestationClient::new() {
+        Ok(client) => client,
+        Err(e) => {
+            error!("Failed to create AttestationClient: {}", e);
+            return Err(Box::new(ServerError::AttestationLibraryInit));
+        }
+    };
+    trace!("Created AttestationClient successfully");
+    Ok(attestation_client)
+}
+
+#[instrument(skip(maa), fields(version = %VERSION))]
+pub async fn attest(
+    maa: String,
+    x_ms_request_id: String,
+) -> Result<impl warp::Reply, std::convert::Infallible> {
+    trace!("Maa: {}", maa);
+
+    let mut attestation_client = match create_attestation_client() {
+        Ok(attestation_client) => attestation_client,
+        Err(e) => {
+            return Ok(warp::reply::with_status(
+                format!("{}", e),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    let token = match fetch_maa_token(&mut attestation_client, &maa) {
+        Ok(token) => token,
+        Err(e) => {
+            error!("Failed to fetch MAA token: {}", e);
+            return Ok(warp::reply::with_status(
+                format!("{e}"),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    Ok(warp::reply::with_status(token, warp::http::StatusCode::OK))
+}
+
+fn fetch_maa_token(attestation_client: &mut AttestationClient, maa: &str) -> Res<String> {
+    // Get MAA token from CVM guest attestation library
+    info!("Fetching MAA token from {maa}");
+
+    let t = attestation_client.attest("{}".as_bytes(), PCR0_TO_15_BITMASK, maa)?;
+
+    let token = String::from_utf8(t).unwrap();
+    trace!("Fetched MAA token: {token}");
+    Ok(token)
+}
+
+#[instrument(skip( body), fields(version = %VERSION))]
+pub async fn decrypt(
+    x_ms_request_id: String,
+    body: bytes::Bytes,
+) -> Result<impl warp::Reply, std::convert::Infallible> {
+    let enc_key = body.to_vec();
+    trace!("Encrypted key: {:?}", enc_key);
+
+    let mut attestation_client = match create_attestation_client() {
+        Ok(attestation_client) => attestation_client,
+        Err(e) => {
+            return Ok(warp::reply::with_status(
+                format!("{}", e),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    let decrypted_key = match attestation_client.decrypt(&enc_key, PCR0_TO_15_BITMASK) {
+        Ok(decrypted_key) => decrypted_key,
+        Err(e) => {
+            error!("Failed to decrypt key: {}", e);
+            return Ok(warp::reply::with_status(
+                format!("{}", ServerError::TPMDecryptionFailure),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    Ok(warp::reply::with_status(
+        String::from_utf8(decrypted_key).unwrap(),
+        warp::http::StatusCode::OK,
+    ))
+}

--- a/azure-attestation-proxy/src/main.rs
+++ b/azure-attestation-proxy/src/main.rs
@@ -1,0 +1,51 @@
+use azure_attestation_proxy::{attest, decrypt, get_socket_listener, Res};
+use tracing::subscriber;
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter, FmtSubscriber};
+use warp::Filter;
+
+const SOCKET_PATH: &str = "/var/run/azure-attestation-proxy/azure-attestation-proxy.sock";
+
+#[tokio::main]
+async fn main() -> Res<()> {
+    // Build a simple subscriber that outputs to stdout
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace")),
+        )
+        .with_file(true)
+        .with_line_number(true)
+        .with_thread_ids(true)
+        .with_span_events(FmtSpan::NEW)
+        .json()
+        .finish();
+
+    // Set the subscriber as global default
+    subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let listener = match get_socket_listener(SOCKET_PATH).await {
+        Ok(listener) => listener,
+        Err(e) => return Err(e),
+    };
+
+    let stream = tokio_stream::wrappers::UnixListenerStream::new(listener);
+
+    let attest = warp::get()
+        .and(warp::path::path("attest"))
+        .and(warp::path::end())
+        .and(warp::header::header::<String>("maa"))
+        .and(warp::header::header::<String>("x-ms-request-id"))
+        .and_then(attest);
+
+    let decrypt = warp::get()
+        .and(warp::path::path("decrypt"))
+        .and(warp::path::end())
+        .and(warp::header::header::<String>("x-ms-request-id"))
+        .and(warp::body::bytes())
+        .and_then(decrypt);
+
+    let routes = attest.or(decrypt);
+
+    warp::serve(routes).serve_incoming(stream).await;
+
+    Ok(())
+}

--- a/cgpuvm-attest/Cargo.toml
+++ b/cgpuvm-attest/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Antoine Delignat-Lavaud <antdl@microsoft.com>"]
 edition = "2021"
 license = "MIT"
 description = "FFI for Confidential GPU VM Guest Attestation Library"
-repository = "https://github.com/ad-l/ohttp"
+repository = "https://github.com/ad-l/cvm-guest-attestation"
 
 [features]
 default = []
@@ -13,10 +13,4 @@ default = []
 [dependencies]
 libc = "0.2.0"
 tracing = "0.1"
-thiserror = "1"
-
-[dependencies.ohttp]
-git = "https://github.com/microsoft/ohttp.git"
-branch = "main"
-features = ["server"]
-default-features = false
+thiserror = "2.0.12"

--- a/cgpuvm-attest/src/lib.rs
+++ b/cgpuvm-attest/src/lib.rs
@@ -32,6 +32,7 @@ extern "C" {
     ) -> c_int;
 }
 
+#[derive(Debug)]
 pub struct AttestationClient {
     p_attestation_client: *mut c_void,
 }

--- a/ohttp-server/Cargo.toml
+++ b/ohttp-server/Cargo.toml
@@ -33,9 +33,14 @@ tracing-subscriber = { version = "0.3.18", features = ["default", "json", "env-f
 thiserror = "1"
 uuid = { version = "1.0", features = ["v4"] }
 hyper-unix-connector = "0.2.2"
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [dependencies.cgpuvm-attest]
 path= "../cgpuvm-attest"
+features = []
+
+[dependencies.azure-attestation-proxy]
+path= "../azure-attestation-proxy"
 features = []
 
 [dependencies.bhttp]
@@ -52,3 +57,4 @@ default-features = false
 [dev-dependencies]
 hyper = "0.14"  # Use the latest patch version for the 0.14.x series
 ohttp-client = {path = "../external/attested-ohttp-client/ohttp-client" }
+

--- a/ohttp-server/src/attest.rs
+++ b/ohttp-server/src/attest.rs
@@ -99,7 +99,7 @@ pub fn fetch_maa_token(attestation_client: &mut AttestationClient, maa: &str) ->
 
 /// Retrieves the HPKE private key from Azure KMS.
 ///
-async fn get_hpke_private_key_from_kms(
+pub async fn get_hpke_private_key_from_kms(
     kms: &str,
     kid: u8,
     token: &str,

--- a/ohttp-server/src/err.rs
+++ b/ohttp-server/src/err.rs
@@ -29,6 +29,6 @@ pub enum ServerError {
     TPMDecryptionFailure,
     #[error("GPU attestation failed: {0}")]
     GPUAttestationFailure(String),
-    #[error("Target response failed: {0}")]
+    #[error("{0}")]
     TargetRequestError(String),
 }

--- a/ohttp-server/src/lib.rs
+++ b/ohttp-server/src/lib.rs
@@ -37,7 +37,7 @@ use warp::hyper::Body;
 use tracing::{error, instrument, trace};
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter, FmtSubscriber};
 
-const VERSION: &str = "0.0.74.2";
+const VERSION: &str = "0.0.74.3";
 
 /// Copies headers from the encapsulated request and logs them.
 ///
@@ -111,11 +111,7 @@ pub async fn post_request_to_target(
         .await?;
 
     if !response.status().is_success() {
-        let error_msg = format!(
-            "{}{}",
-            response.status(),
-            response.text().await.unwrap_or_default()
-        );
+        let error_msg = response.text().await.unwrap_or_default();
         return Err(Box::new(ServerError::TargetRequestError(error_msg)));
     }
 


### PR DESCRIPTION
Add azure attestation proxy service.

This PR is the first step to move attestation from the OHTTP gateway to a service inside the CVM. This includes -
1. Creation of a new crate called `azure-attestation-proxy` to handle attestation.
2. installation script and other dependencies to add this as a systemd service.