### PR TITLE
Change the MAA endpoints being used to match Singularity.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KMS ?= https://accconfinferenceproduction.confidential-ledger.azure.com
-MAA ?= https://confinfermaaeus2test.eus2.test.attest.azure.net
+MAA ?= https://maanosecureboottestyfu.eus.attest.azure.net
 REQUEST_ID ?= "12345678-1234-5678-1234-567812345678"
 
 export TARGET ?= http://127.0.0.1:3000

--- a/ohttp-server/src/tests.rs
+++ b/ohttp-server/src/tests.rs
@@ -666,10 +666,7 @@ async fn test_attestation_proxy() {
         .method(Method::GET)
         .uri(addr)
         .header("x-ms-request-id", "12345678-1234-5678-1234-567812345678")
-        .header(
-            "maa",
-            "https://confinfermaaeus2test.eus2.test.attest.azure.net",
-        )
+        .header("maa", "https://maanosecureboottestyfu.eus.attest.azure.net")
         .body(Body::empty())
         .expect("request builder");
 

--- a/ohttp-server/src/utils.rs
+++ b/ohttp-server/src/utils.rs
@@ -2,7 +2,7 @@ pub type Res<T> = Result<T, Box<dyn std::error::Error>>;
 
 pub const DEFAULT_KMS_URL: &str =
     "https://accconfinferenceproduction.confidential-ledger.azure.com/app/key";
-pub const DEFAULT_MAA_URL: &str = "https://confinfermaaeus2test.eus2.test.attest.azure.net";
+pub const DEFAULT_MAA_URL: &str = "https://maanosecureboottestyfu.eus.attest.azure.net";
 pub const DEFAULT_GPU_ATTESTATION_SOCKET: &str = "/var/run/gpu-attestation/gpu-attestation.sock";
 
 use bhttp::Mode;


### PR DESCRIPTION
This PR updates the default MAA endpoint URLs to align with the new Singularity service address.

- Updated the DEFAULT_MAA_URL constant in utils.rs
- Adjusted the expected MAA header in the integration test
- Updated the Makefile’s MAA variable