### PR TITLE
Change decrypt from HTTP GET to POST.

### DIFF
--- a/azure-attestation-proxy/src/main.rs
+++ b/azure-attestation-proxy/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Res<()> {
         .and(warp::header::header::<String>("x-ms-request-id"))
         .and_then(attest);
 
-    let decrypt = warp::get()
+    let decrypt = warp::post()
         .and(warp::path::path("decrypt"))
         .and(warp::path::end())
         .and(warp::header::header::<String>("x-ms-request-id"))

--- a/ohttp-server/src/tests.rs
+++ b/ohttp-server/src/tests.rs
@@ -612,7 +612,7 @@ impl TestProxyServer {
             .and(warp::header::header::<String>("x-ms-request-id"))
             .and_then(attest);
 
-        let decrypt = warp::get()
+        let decrypt = warp::post()
             .and(warp::path::path("decrypt"))
             .and(warp::path::end())
             .and(warp::header::header::<String>("x-ms-request-id"))
@@ -688,7 +688,7 @@ async fn test_attestation_proxy() {
     let enc_key = b64.decode(&key).unwrap_or_default();
 
     let req = Request::builder()
-        .method(Method::GET)
+        .method(Method::POST)
         .uri(addr)
         .header("x-ms-request-id", "12345678-1234-5678-1234-567812345678")
         .body(enc_key.into())


### PR DESCRIPTION
Updates the decrypt endpoint to use HTTP POST instead of GET, aligning both the proxy implementation and tests to accept a request body.

- Switch decrypt route from warp::get() to warp::post() in both server and tests.
- Adjust client test to send a POST with a body payload.
