### PR TITLE
Move the debug endpoint to the ACL based KMS as well.

### DIFF
--- a/ohttp-server/src/tests.rs
+++ b/ohttp-server/src/tests.rs
@@ -512,7 +512,7 @@ async fn kms_test_invalid_kms_url() {
 }
 
 const KMS_URL_SERVER_DEBUG: &str =
-    "https://accconfinferencedebug.confidential-ledger.azure.com/app/key";
+    "https://accconfinferencedebug1.confidential-ledger.azure.com/app/key";
 
 #[tokio::test]
 // mismatched KMS for client and server


### PR DESCRIPTION
This PR updates the debug KMS endpoint in tests to point at the new ACL-based KMS URL.

-Adjust the KMS_URL_SERVER_DEBUG constant to the updated host with a debug1 suffix.
-No other code changes outside of tests.