### PR TITLE
add address as environment variable OHTTP_BIND_ADDRESS

### DIFF
--- a/docker/server/run.sh
+++ b/docker/server/run.sh
@@ -34,6 +34,10 @@ if [[ -n ${LOCAL_KEY} ]]; then
   CMD="$CMD --local-key"
 fi
 
+if [[ -n ${OHTTP_BIND_ADDRESS} ]]; then
+  CMD="$CMD --address ${OHTTP_BIND_ADDRESS}"
+fi
+
 if [[ -n ${INJECT_HEADERS} ]]; then 
   CMD="$CMD --inject-request-headers ${INJECT_HEADERS}"
 fi


### PR DESCRIPTION
From the attested-ohttp-server repo:

Default behavior (documented in README & Makefile):
http://127.0.0.1:9443/discover

Local testing uses:
docker run --net=host

→ loopback works locally

But in Kubernetes:

Envoy is in a different pod
Loopback (127.0.0.1) is not reachable
Envoy must reach PodIP


The OHTTP sidecar must bind to 0.0.0.0:9443

ohttp-server --address 0.0.0.0:9443 (env variable)